### PR TITLE
Naive B3S support

### DIFF
--- a/niimprint/__main__.py
+++ b/niimprint/__main__.py
@@ -4,15 +4,16 @@ import re
 import click
 from PIL import Image
 
-from niimprint import BluetoothTransport, PrinterClient, SerialTransport
+# TODO: Not using poetry, why is this needed?
+from printer import BluetoothTransport, PrinterClient, SerialTransport
 
 
 @click.command("print")
 @click.option(
     "-m",
     "--model",
-    type=click.Choice(["b1", "b18", "b21", "d11", "d110"], False),
-    default="b21",
+    type=click.Choice(["b1", "b18", "b21", "b3s", "d11", "d110"], False),
+    default="b3s",
     show_default=True,
     help="Niimbot printer model",
 )
@@ -65,6 +66,9 @@ def print_cmd(model, conn, addr, density, rotate, image, verbose):
     )
 
     if conn == "bluetooth":
+        # TODO: Don't upstream
+        addr = addr if addr is not None else "D8:F7:22:05:07:31"
+
         assert conn is not None, "--addr argument required for bluetooth connection"
         addr = addr.upper()
         assert re.fullmatch(r"([0-9A-F]{2}:){5}([0-9A-F]{2})", addr), "Bad MAC address"
@@ -75,6 +79,8 @@ def print_cmd(model, conn, addr, density, rotate, image, verbose):
 
     if model in ("b1", "b18", "b21"):
         max_width_px = 384
+    if model in ("b3s"):
+        max_width_px = 560
     if model in ("d11", "d110"):
         max_width_px = 96
 


### PR DESCRIPTION
Hey! I recently bought a B3S and stumbled upon this project.

I took some USB serial captures from the official Win application, and managed to make my device work reasonably well for my usecases with the library. It appears that it's communication is highly similar to other supported models, but the device has a larger response to the `GET_PRINT_STATUS` request, and needs some interactive flow control/backoff to print images with a height which cannot fit into it's internal buffer.

To make continuous printing work I have changed the serial transport to be non-blocking, and implemented similar status handling to what the PC application does. (The backoff on `free_buffer < 0x100` is just a guess from my USB captures)

Telling the truth I don't have much interest/experience in Python, but I thought this draft might be useful for someone who enjoys coding in the language more than I do. If you were to implement some rudimentary way into the library that would allow easier implementation of model/device specific behavior, I would be happy to port the code to that.

Feel free to mention me if you need some experiments/captures done with a B3S in the future.