### PR TITLE
Wait for finish to send end_print

### DIFF
--- a/niimprint/printer.py
+++ b/niimprint/printer.py
@@ -111,7 +111,14 @@ class PrinterClient:
         for pkt in self._encode_image(image):
             self._send(pkt)
         self.end_page_print()
-        time.sleep(0.3)  # FIXME: Check get_print_status()
+        while True:
+            status = self.get_print_status()
+            if status["error"]:
+                raise RuntimeError("Failure during print")
+            if status["finished"] == 1:
+                break
+            print(f"Progress: {status['progress']}")
+
         while not self.end_print():
             time.sleep(0.1)
 
@@ -284,5 +291,11 @@ class PrinterClient:
 
     def get_print_status(self):
         packet = self._transceive(RequestCodeEnum.GET_PRINT_STATUS, b"\x01", 16)
-        page, progress1, progress2 = struct.unpack(">HBB", packet.data)
-        return {"page": page, "progress1": progress1, "progress2": progress2}
+        finished = bool(packet.data[1])
+        progress = packet.data[2]
+        error = packet.data[6]
+        return {
+            "finished": finished,
+            "progress": progress,
+            "error": error,
+        }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "niimprint"
-version = "0.1.0"
+version = "0.1.1"
 description = ""
 authors = []
 


### PR DESCRIPTION
First, thanks a lot for your work!
I recently bought a B21 and .. well, want to make it more complicated than simply installing an app!

I noticed the same behaviour as in #3 and realized increasing the sleep duration also helped. 

Somehow I got the exception below, when calling get_print_status. Unsure if this is related to using usb? So I had to modify it a bit.

```
/niimprint/niimprint/printer.py", line 299, in get_print_status
    page, progress1, progress2 = struct.unpack(">HBB", packet.data)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
struct.error: unpack requires a buffer of 4 bytes
```

Right now it simply prints `Progress: VALUE`, if you want that changed or have it send to logger i can change that of course.

Looking forward to your feedback!
 
