### PR TITLE
Enable GitHub Actions

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,0 +1,8 @@
+name: Linters
+on: [ push, pull_request ]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: chartboost/ruff-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Test
+on: [ push, pull_request ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up Poetry
+        uses: snok/install-poetry@v1
+
+      - run: poetry install --no-interaction
+
+      - name: Test niimprint running
+        run: python -m niimprint --help

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,4 +20,4 @@ jobs:
       - run: poetry install --no-interaction
 
       - name: Test niimprint running
-        run: python -m niimprint --help
+        run: poetry run python -m niimprint --help


### PR DESCRIPTION
- **Linters** currently includes only Ruff,  but can be easily amended to add linters as needed (maybe mypy, markdown lint, etc).
- **Test** performs a basic installation of the package and tries to run the CLI with `--help`. It may be extended in the future to run extra tests as needed. Note that this action currently fails because it tries to test Python 3.12, which requires #18 to be merged.