### PR TITLE
Fixed image being cut off by adding longer timeout delay.

### DIFF
--- a/niimprint/printer.py
+++ b/niimprint/printer.py
@@ -75,7 +75,7 @@ class BluetoothTransport(BaseTransport):
 class SerialTransport(BaseTransport):
     def __init__(self, port: str = "auto"):
         port = port if port != "auto" else self._detect_port()
-        self._serial = serial.Serial(port=port, baudrate=115200, timeout=0.5)
+        self._serial = serial.Serial(port=port, baudrate=115200, timeout=2.5)
 
     def _detect_port(self):
         all_ports = list(list_comports())


### PR DESCRIPTION
fix(printer): Fixed images not being able to print fully.

This change "fixes" an issue of images not being able to print fully. This is what I've done to allow my printer to print 50x80mm labels with a fair amount of detail and density. Only drawback is that it increases print time. This might be more of a patch job than a fix, but I figured I share what I did to make consistent prints.

Issue: #3