### PR TITLE
fix printing larger labels on D11

### DIFF
--- a/niimprint/__main__.py
+++ b/niimprint/__main__.py
@@ -89,7 +89,7 @@ def print_cmd(model, conn, addr, density, rotate, image, verbose):
     assert image.width <= max_width_px, f"Image width too big for {model.upper()}"
 
     printer = PrinterClient(transport)
-    printer.print_image(image, density=density)
+    printer.print_image(image, density=density, model=model)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Printing larger labels (more than 210 pixels height) is currently broken on my D11. Seems like some print options and a small delay in sending the print data is needed in order to make this work again.
This version is working on my D11.